### PR TITLE
ci: add shared security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,16 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  security:
+    uses: damoun/.github/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write
+    secrets: inherit


### PR DESCRIPTION
Adds the reusable security workflow (Semgrep + Gitleaks + Zizmor) from `damoun/.github` and removes any inline duplicates.

Closes https://github.com/damoun/issues/issues/2