### PR TITLE
feat: auto-update month/year on last day of month

### DIFF
--- a/.github/workflows/fetch-codes.yml
+++ b/.github/workflows/fetch-codes.yml
@@ -13,6 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Configure git credentials
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
@@ -31,8 +39,6 @@ jobs:
 
       - name: Commit if changed
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           if git diff --quiet codes.json; then
             echo "No changes to codes.json"
             exit 0

--- a/.github/workflows/fetch-codes.yml
+++ b/.github/workflows/fetch-codes.yml
@@ -12,7 +12,7 @@ jobs:
   fetch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:

--- a/.github/workflows/update-month-year.yml
+++ b/.github/workflows/update-month-year.yml
@@ -1,0 +1,41 @@
+name: Update Month/Year
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Update month/year
+        run: python scripts/update_month_year.py
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          FILES="index.html privacy.html terms.html beginners-guide.html rewards-guide.html event-codes.html sitemap.xml"
+          git add $FILES
+          if git diff --cached --quiet; then
+            echo "No changes"
+            exit 0
+          fi
+          MONTH_YEAR=$(python -c "
+          from datetime import date, timedelta
+          d = date.today()
+          nxt = (d.replace(day=1) + timedelta(days=32)).replace(day=1)
+          print(nxt.strftime('%B %Y'))
+          ")
+          git commit -m "chore: update month/year to ${MONTH_YEAR}"
+          git push

--- a/.github/workflows/update-month-year.yml
+++ b/.github/workflows/update-month-year.yml
@@ -18,6 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Configure git credentials
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
@@ -30,8 +38,6 @@ jobs:
 
       - name: Commit if changed
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           FILES="index.html privacy.html terms.html beginners-guide.html rewards-guide.html event-codes.html sitemap.xml"
           git add $FILES
           if git diff --cached --quiet; then

--- a/.github/workflows/update-month-year.yml
+++ b/.github/workflows/update-month-year.yml
@@ -17,7 +17,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:

--- a/.github/workflows/update-month-year.yml
+++ b/.github/workflows/update-month-year.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force update regardless of date'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -20,6 +25,8 @@ jobs:
 
       - name: Update month/year
         run: python scripts/update_month_year.py
+        env:
+          FORCE_UPDATE: ${{ inputs.force }}
 
       - name: Commit if changed
         run: |

--- a/scripts/update_month_year.py
+++ b/scripts/update_month_year.py
@@ -81,8 +81,10 @@ def update_sitemap(path: Path, new_date: str) -> bool:
 
 
 def main() -> None:
+    import os
     today = date.today()
-    if not is_last_day_of_month(today):
+    force = os.environ.get("FORCE_UPDATE", "").lower() in ("1", "true")
+    if not force and not is_last_day_of_month(today):
         print(f"Today ({today}) is not the last day of the month. Nothing to do.")
         sys.exit(0)
 

--- a/scripts/update_month_year.py
+++ b/scripts/update_month_year.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Update month/year strings across HTML files and sitemap.xml to the next month.
+
+Intended to run on the last day of each month via GitHub Actions.
+"""
+
+import re
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+
+def next_month(d: date) -> tuple[str, int]:
+    """Return (month_name, year) for the month after d."""
+    first_next = (d.replace(day=1) + timedelta(days=32)).replace(day=1)
+    return first_next.strftime("%B"), first_next.year
+
+
+def is_last_day_of_month(d: date) -> bool:
+    next_day = d + timedelta(days=1)
+    return next_day.month != d.month
+
+
+HTML_FILES = [
+    "index.html",
+    "privacy.html",
+    "terms.html",
+    "beginners-guide.html",
+    "rewards-guide.html",
+    "event-codes.html",
+]
+
+MONTH_YEAR_RE = re.compile(r"[A-Z][a-z]+ 20\d\d")
+DATE_RE = re.compile(r"20\d\d-\d{2}-\d{2}")
+
+
+def update_html(path: Path, month: str, year: int) -> bool:
+    text = path.read_text()
+    new_text = MONTH_YEAR_RE.sub(f"{month} {year}", text)
+    if new_text != text:
+        path.write_text(new_text)
+        return True
+    return False
+
+
+def update_json_ld_dates(path: Path, new_date: str) -> bool:
+    text = path.read_text()
+    new_text = re.sub(
+        r'("datePublished"|"dateModified"): "20\d\d-\d{2}-\d{2}"',
+        lambda m: f'{m.group(1)}: "{new_date}"',
+        text,
+    )
+    if new_text != text:
+        path.write_text(new_text)
+        return True
+    return False
+
+
+def update_sitemap(path: Path, new_date: str) -> bool:
+    text = path.read_text()
+    lines = text.splitlines(keepends=True)
+    result = []
+    skip_first = True
+    changed = False
+    for line in lines:
+        if "<lastmod>" in line and skip_first:
+            # Skip homepage lastmod — managed by fetch-codes.yml
+            skip_first = False
+            result.append(line)
+            continue
+        if "<lastmod>" in line:
+            new_line = DATE_RE.sub(new_date, line)
+            if new_line != line:
+                changed = True
+            result.append(new_line)
+        else:
+            result.append(line)
+    if changed:
+        path.write_text("".join(result))
+    return changed
+
+
+def main() -> None:
+    today = date.today()
+    if not is_last_day_of_month(today):
+        print(f"Today ({today}) is not the last day of the month. Nothing to do.")
+        sys.exit(0)
+
+    month, year = next_month(today)
+    new_date = f"{year}-{list(__import__('calendar').month_name).index(month):02d}-01"
+    print(f"Updating to: {month} {year} ({new_date})")
+
+    root = Path(__file__).parent.parent
+    changed_files = []
+
+    for filename in HTML_FILES:
+        path = root / filename
+        if not path.exists():
+            continue
+        html_changed = update_html(path, month, year)
+        date_changed = update_json_ld_dates(path, new_date)
+        if html_changed or date_changed:
+            changed_files.append(filename)
+            print(f"  Updated: {filename}")
+
+    sitemap = root / "sitemap.xml"
+    if update_sitemap(sitemap, new_date):
+        changed_files.append("sitemap.xml")
+        print(f"  Updated: sitemap.xml")
+
+    if not changed_files:
+        print("No changes needed.")
+    else:
+        print(f"Done. {len(changed_files)} file(s) updated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `scripts/update_month_year.py` to replace stale "Month YYYY" strings across HTML files and sitemap.xml with the next month/year
- Adds `.github/workflows/update-month-year.yml` that runs daily and executes the script only on the last day of each month

## Test plan
- [ ] Verify script logic with a simulated April 30 date (dry-run tested locally)
- [ ] Confirm `index.html`, `privacy.html`, `terms.html` month/year strings are replaced
- [ ] Confirm JSON-LD `datePublished`/`dateModified` in guide pages are updated
- [ ] Confirm sitemap.xml secondary `<lastmod>` dates are updated (homepage entry left untouched for fetch-codes.yml)
- [ ] Trigger `workflow_dispatch` on the workflow to confirm it runs without errors